### PR TITLE
The -XPOST is not necessary

### DIFF
--- a/deployments/hourly-backup-job.yaml
+++ b/deployments/hourly-backup-job.yaml
@@ -15,6 +15,5 @@ spec:
               - "bin/bash"
               - "-c"
               - "curl reshifter:8080/v1/backup"
-              - "-XPOST"
               - "-d '{ \"endpoint\": \"http://172.17.0.2:2379\", \"remote\" : \"play.minio.io:9000\", \"bucket\" : \"reshifter-2017\" }'"
           restartPolicy: OnFailure


### PR DESCRIPTION
With -d curl automatically use the post methode.

[https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/](Unnecessary use of curl -X)