### PR TITLE
Add error codes to cli

### DIFF
--- a/rcli/cmd/backup.go
+++ b/rcli/cmd/backup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"errors"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/mhausenblas/reshifter/pkg/backup"
@@ -20,7 +21,7 @@ var createBackupCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates a backup of a Kubernetes cluster",
 	Long:  `Backups are created by travesing the underlying etcd and storing the content in a ZIP file in the local filesystem and optionally in an S3-compatible remote storage`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (error) {
 		ep := cmd.Flag("endpoint").Value.String()
 		target := cmd.Flag("target").Value.String()
 		remote := cmd.Flag("remote").Value.String()
@@ -32,7 +33,7 @@ var createBackupCmd = &cobra.Command{
 		bid, err := backup.Backup(ep, target, remote, bucket)
 		if err != nil {
 			log.Error(err)
-			return
+			return err
 		}
 		if os.Getenv("RS_BACKUP_STRATEGY") != types.ReapFunctionRender {
 			fmt.Printf("Successfully created backup: %s/%s.zip\n", target, bid)
@@ -40,23 +41,27 @@ var createBackupCmd = &cobra.Command{
 				fmt.Printf("Pushed to remote %s in bucket %s\n\n", remote, bucket)
 			}
 		}
+
+		return nil
 	},
 }
 
 var listBackupCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists backups of a Kubernetes cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (error) {
 		remote := cmd.Flag("remote").Value.String()
 		bucket := cmd.Flag("bucket").Value.String()
 		backupIDs, err := backup.List(remote, bucket)
 		if err != nil {
 			log.Error(err)
-			return
+			return err
 		}
 		for _, bid := range backupIDs {
 			fmt.Printf("%s\n", bid)
 		}
+
+		return nil
 	},
 }
 

--- a/rcli/cmd/backup.go
+++ b/rcli/cmd/backup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-	"errors"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/mhausenblas/reshifter/pkg/backup"

--- a/rcli/cmd/stats.go
+++ b/rcli/cmd/stats.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"errors"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/mhausenblas/reshifter/pkg/discovery"
@@ -14,10 +15,10 @@ import (
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Collects stats about Kubernetes-related keys from an etcd endpoint",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (error) {
 		ep := cmd.Flag("endpoint").Value.String()
 		fmt.Printf("Collecting stats from etcd endpoint %s\n", ep)
-		docollectstats(ep)
+		return docollectstats(ep)
 	},
 }
 
@@ -26,16 +27,16 @@ func init() {
 	statsCmd.Flags().StringP("endpoint", "e", "http://127.0.0.1:2379", "The URL of the etcd to collect stats from")
 }
 
-func docollectstats(endpoint string) {
+func docollectstats(endpoint string) (error) {
 	if endpoint == "" || strings.Index(endpoint, "http") != 0 {
 		merr := "The endpoint is malformed"
 		log.Error(merr)
-		return
+		return errors.New(merr)
 	}
 	_, _, _, err := discovery.ProbeEtcd(endpoint)
 	if err != nil {
 		log.Errorf(fmt.Sprintf("%s", err))
-		return
+		return err
 	}
 	vlk, vls, derr := discovery.CountKeysFor(endpoint, types.LegacyKubernetesPrefix, types.LegacyKubernetesPrefixLast)
 	if derr != nil {
@@ -43,12 +44,15 @@ func docollectstats(endpoint string) {
 	}
 	vk, vs, err := discovery.CountKeysFor(endpoint, types.KubernetesPrefix, types.KubernetesPrefixLast)
 	if err != nil && derr != nil {
-		log.Error(fmt.Sprintf("Having problems calculating stats: %s", err))
-		return
+		serr := fmt.Sprintf("Having problems calculating stats: %s", err)
+		log.Error(serr)
+		return errors.New(serr)
 	}
 	fmt.Printf("Vanilla Kubernetes [keys:%d, size:%d]\n", vlk+vk, vls+vs)
 	osk, oss, _ := discovery.CountKeysFor(endpoint, types.OpenShiftPrefix, types.OpenShiftPrefixLast)
 	if osk > 0 {
 		fmt.Printf("OpenShift [keys:%d, size:%d]\n\n", osk, oss)
 	}
+
+	return nil
 }


### PR DESCRIPTION
This changeset introduces posix style exit codes when a command fails. This makes it significantly easier to run the tool in an automated fashion.

This was tested specifically for the backup scenarios. Test suite passed against this changeset but it didn't look like there was explicit coverage of the cli tool.